### PR TITLE
feat: 会社自動検出機能を実装

### DIFF
--- a/frontend/src/hooks/usePdfProcessor.ts
+++ b/frontend/src/hooks/usePdfProcessor.ts
@@ -23,7 +23,8 @@ export interface UsePdfProcessorReturn {
   processFile: (
     fileToProcess: File,
     companyId: CompanyOptionValue,
-    companyLabelForError: string // エラーメッセージ表示用の会社ラベル
+    companyLabelForError: string, // エラーメッセージ表示用の会社ラベル
+    enableAutoDetection?: boolean // 自動検出を有効にするかどうか
   ) => Promise<void>;
 }
 
@@ -37,10 +38,11 @@ export const usePdfProcessor = ({
     async (
       fileToProcess: File,
       companyId: CompanyOptionValue,
-      companyLabelForError: string // エラーメッセージ用に会社ラベルを受け取る
+      companyLabelForError: string, // エラーメッセージ用に会社ラベルを受け取る
+      enableAutoDetection: boolean = false // 自動検出フラグ
     ): Promise<void> => {
-      if (!companyId) {
-        // companyId の存在チェックを追加
+      if (!enableAutoDetection && !companyId) {
+        // 自動検出が無効で、companyIdが未選択の場合のみエラー
         toast.error('会社が選択されていません。');
         onError('会社未選択', fileToProcess, companyLabelForError);
         return;
@@ -71,7 +73,10 @@ export const usePdfProcessor = ({
         // FormDataオブジェクトを作成してファイルと他のデータを格納
         const formData = new FormData();
         formData.append('pdfFile', fileToProcess, fileToProcess.name); // 第3引数でファイル名を指定
-        formData.append('companyId', companyId);
+        if (companyId) {
+          formData.append('companyId', companyId);
+        }
+        formData.append('enableAutoDetection', enableAutoDetection.toString());
         // 必要に応じて他のデータも formData.append() で追加できます
         // 例: formData.append('originalFileName', fileToProcess.name);
 

--- a/frontend/src/pages/admin/CompanyDetectionSettings.tsx
+++ b/frontend/src/pages/admin/CompanyDetectionSettings.tsx
@@ -1,0 +1,58 @@
+// 会社検出ルール設定画面（将来の実装用プレースホルダー）
+import React from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const CompanyDetectionSettings: React.FC = () => {
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">会社自動検出設定</h1>
+      
+      <Card className="p-6">
+        <h2 className="text-lg font-semibold mb-4">検出ルール管理</h2>
+        <p className="text-muted-foreground mb-4">
+          PDF内容から会社を自動検出するためのルールを設定できます。
+        </p>
+        
+        <div className="space-y-4">
+          <div className="border rounded-lg p-4">
+            <h3 className="font-medium mb-2">野原G住環境</h3>
+            <p className="text-sm text-muted-foreground mb-2">
+              検出キーワード: 野原グループ、野原G、NOHARA
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" disabled>編集</Button>
+              <Button variant="outline" size="sm" disabled>テスト</Button>
+            </div>
+          </div>
+          
+          <div className="border rounded-lg p-4">
+            <h3 className="font-medium mb-2">加藤ベニヤ池袋_ミサワホーム</h3>
+            <p className="text-sm text-muted-foreground mb-2">
+              検出キーワード: 加藤ベニヤ、ミサワホーム、池袋
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" disabled>編集</Button>
+              <Button variant="outline" size="sm" disabled>テスト</Button>
+            </div>
+          </div>
+        </div>
+        
+        <div className="mt-6 p-4 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
+          <p className="text-sm">
+            <strong>注意:</strong> この機能は開発中です。現在、検出ルールはバックエンドで固定されています。
+          </p>
+        </div>
+      </Card>
+      
+      <Card className="p-6 mt-6">
+        <h2 className="text-lg font-semibold mb-4">検出履歴と精度</h2>
+        <p className="text-muted-foreground">
+          過去の検出結果と精度の統計を表示する予定です。
+        </p>
+      </Card>
+    </div>
+  );
+};
+
+export default CompanyDetectionSettings;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,6 +43,11 @@ export interface PdfProcessSuccessResponse {
   promptUsedIdentifier: string;
   dbRecordId: string; // UUIDなど
   message?: string; // 成功メッセージなど
+  // 自動検出関連のフィールド
+  detectedCompany?: string | null;
+  detectionConfidence?: number;
+  detectionMethod?: string;
+  wasManuallyOverridden?: boolean;
 }
 
 export interface PdfProcessErrorResponse {

--- a/supabase/migrations/20250604_add_company_detection_fields.sql
+++ b/supabase/migrations/20250604_add_company_detection_fields.sql
@@ -1,0 +1,28 @@
+-- 会社自動検出機能のためのフィールド追加
+ALTER TABLE work_orders
+ADD COLUMN IF NOT EXISTS detected_company_id TEXT,
+ADD COLUMN IF NOT EXISTS detection_confidence DECIMAL(3, 2) CHECK (detection_confidence >= 0 AND detection_confidence <= 1),
+ADD COLUMN IF NOT EXISTS detection_method TEXT,
+ADD COLUMN IF NOT EXISTS is_manual_override BOOLEAN DEFAULT FALSE;
+
+-- 検出履歴テーブルの作成
+CREATE TABLE IF NOT EXISTS company_detection_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  work_order_id uuid REFERENCES work_orders(id) ON DELETE CASCADE,
+  detected_company_id TEXT NOT NULL,
+  confidence DECIMAL(3, 2) NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+  detection_details JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- インデックスの追加
+CREATE INDEX IF NOT EXISTS idx_work_orders_detected_company ON work_orders(detected_company_id);
+CREATE INDEX IF NOT EXISTS idx_detection_history_work_order ON company_detection_history(work_order_id);
+CREATE INDEX IF NOT EXISTS idx_detection_history_created ON company_detection_history(created_at);
+
+-- コメントの追加
+COMMENT ON COLUMN work_orders.detected_company_id IS '自動検出された会社ID';
+COMMENT ON COLUMN work_orders.detection_confidence IS '検出の信頼度スコア（0.0〜1.0）';
+COMMENT ON COLUMN work_orders.detection_method IS '検出方法（gemini_content_analysis, pattern_matching等）';
+COMMENT ON COLUMN work_orders.is_manual_override IS 'ユーザーが手動で会社を変更したかどうか';
+COMMENT ON TABLE company_detection_history IS '会社検出の履歴を保存し、将来の機械学習に活用';


### PR DESCRIPTION
- データベースに自動検出関連フィールドを追加
  - detected_company_id: 検出された会社ID
  - detection_confidence: 検出の信頼度スコア（0.0〜1.0）
  - detection_method: 検出方法
  - is_manual_override: 手動上書きフラグ
  - company_detection_history: 検出履歴テーブル

- Edge Functionに自動検出ロジックを実装
  - Gemini APIを使用してPDF内容から会社を判定
  - 会社名、ロゴ、住所などから判定
  - JSON形式で検出結果を返す

- フロントエンドUI改善
  - 自動検出トグルスイッチを追加
  - 検出結果と信頼度の表示
  - 手動での会社選択も可能

- API連携の更新
  - enableAutoDetectionフラグの送信
  - 検出結果の受信と表示