### PR TITLE
fix: DenoテストのTypeScriptインポートエラーを修正

### DIFF
--- a/supabase/functions/process-pdf-single/__tests__/gemini-integration.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/gemini-integration.test.ts
@@ -1,6 +1,6 @@
 // Gemini APIモックを使用したEdge Function統合テストのデモンストレーション
 import { assertEquals, assertExists } from '@std/testing/asserts'
-import { afterEach, beforeEach, describe, it } from '@std/testing'
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd'
 import {
   cleanupTestEnv,
   createMockGeminiAI,

--- a/supabase/functions/process-pdf-single/__tests__/index.integration.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/index.integration.test.ts
@@ -1,6 +1,6 @@
 // process-pdf-single 関数の統合テスト（Geminiモック使用）
 import { assertEquals, assertExists } from '@std/testing/asserts'
-import { afterEach, beforeEach, describe, it } from '@std/testing'
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd'
 import {
   assertCorsHeaders,
   assertErrorResponse,

--- a/supabase/functions/process-pdf-single/__tests__/index.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 // process-pdf-single 関数のテスト
 import { assertEquals, assertExists } from '@std/testing/asserts'
-import { afterEach, beforeEach, describe, it } from '@std/testing'
+import { afterEach, beforeEach, describe, it } from '@std/testing/bdd'
 import { stub } from '@std/testing/mock'
 import {
   cleanupTestEnv,

--- a/supabase/functions/process-pdf-single/__tests__/promptRegistry.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/promptRegistry.test.ts
@@ -1,6 +1,6 @@
 // promptRegistry のテスト
 import { assertEquals, assertExists, assertNotEquals } from '@std/testing/asserts'
-import { describe, it } from '@std/testing'
+import { describe, it } from '@std/testing/bdd'
 import { getPrompt, PROMPT_REGISTRY, type PromptFunction } from '../promptRegistry.ts'
 
 describe('promptRegistry', () => {

--- a/supabase/functions/process-pdf-single/__tests__/prompts/katouBeniyaIkebukuro/misawa.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/prompts/katouBeniyaIkebukuro/misawa.test.ts
@@ -1,6 +1,6 @@
 // katouBeniyaIkebukuro/misawa プロンプトのテスト
 import { assertEquals, assertStringIncludes } from '@std/testing/asserts'
-import { describe, it } from '@std/testing'
+import { describe, it } from '@std/testing/bdd'
 import { KATOUBENIYA_MISAWA_PROMPT } from '../../../prompts/katouBeniyaIkebukuro/misawa.ts'
 
 describe('KATOUBENIYA_MISAWA_PROMPT', () => {

--- a/supabase/functions/process-pdf-single/__tests__/prompts/noharaG.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/prompts/noharaG.test.ts
@@ -1,6 +1,6 @@
 // noharaG プロンプトのテスト
 import { assertEquals, assertStringIncludes } from '@std/testing/asserts'
-import { describe, it } from '@std/testing'
+import { describe, it } from '@std/testing/bdd'
 import { NOHARA_G_PROMPT } from '../../prompts/noharaG.ts'
 
 describe('NOHARA_G_PROMPT', () => {


### PR DESCRIPTION
## 概要
- Supabase Edge Functions (Deno) のテストで発生していたTypeScriptインポートエラーを修正
- CI/CD環境でのテスト実行を安定化

## 変更内容
- `@std/testing` から `@std/testing/bdd` へのインポートパスを修正
- Deno標準ライブラリの新しいバージョンに対応
- process-pdf-single関数の全テストファイル（6ファイル）で修正を適用

## テスト
実行したコマンド:
- ローカル環境にDenoがインストールされていないため、静的解析でエラーを特定・修正
- 修正後のインポートパスはDeno公式ドキュメントに準拠

## チェックリスト
- [x] TypeScriptインポートエラーを修正
- [x] Deno標準ライブラリの最新仕様に対応
- [x] 全てのテストファイルで一貫した修正を適用
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)