### PR TITLE
fix: Denoテストの型エラーとimport map設定を修正

### DIFF
--- a/supabase/deno.json
+++ b/supabase/deno.json
@@ -23,7 +23,6 @@
   },
   "compilerOptions": {
     "lib": ["deno.window"],
-    "allowJs": true,
     "strict": true
   },
   "imports": {

--- a/supabase/functions/process-pdf-single/__tests__/promptRegistry.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/promptRegistry.test.ts
@@ -8,19 +8,23 @@ describe('promptRegistry', () => {
     it('NOHARA_Gエントリが正しく設定されている', () => {
       const entry = PROMPT_REGISTRY['NOHARA_G']
       assertExists(entry)
-      assertEquals(entry.companyName, '野原G住環境')
-      assertEquals(entry.version, 'V20250526')
-      assertExists(entry.promptFunction)
-      assertEquals(typeof entry.promptFunction, 'function')
+      if (entry) {
+        assertEquals(entry.companyName, '野原G住環境')
+        assertEquals(entry.version, 'V20250526')
+        assertExists(entry.promptFunction)
+        assertEquals(typeof entry.promptFunction, 'function')
+      }
     })
 
     it('KATOUBENIYA_MISAWAエントリが正しく設定されている', () => {
       const entry = PROMPT_REGISTRY['KATOUBENIYA_MISAWA']
       assertExists(entry)
-      assertEquals(entry.companyName, '加藤ベニヤ池袋_ミサワホーム')
-      assertEquals(entry.version, 'V20250526')
-      assertExists(entry.promptFunction)
-      assertEquals(typeof entry.promptFunction, 'function')
+      if (entry) {
+        assertEquals(entry.companyName, '加藤ベニヤ池袋_ミサワホーム')
+        assertEquals(entry.version, 'V20250526')
+        assertExists(entry.promptFunction)
+        assertEquals(typeof entry.promptFunction, 'function')
+      }
     })
 
     it('各エントリが必要なプロパティを持っている', () => {
@@ -68,27 +72,33 @@ describe('promptRegistry', () => {
     it('NOHARA_Gのプロンプト関数がファイル名を受け取り文字列を返す', () => {
       const entry = getPrompt('NOHARA_G')
       assertExists(entry)
-      const result = entry.promptFunction('test.pdf')
-      assertEquals(typeof result, 'string')
-      assertNotEquals(result, '')
+      if (entry) {
+        const result = entry.promptFunction('test.pdf')
+        assertEquals(typeof result, 'string')
+        assertNotEquals(result, '')
+      }
     })
 
     it('KATOUBENIYA_MISAWAのプロンプト関数がファイル名を受け取り文字列を返す', () => {
       const entry = getPrompt('KATOUBENIYA_MISAWA')
       assertExists(entry)
-      const result = entry.promptFunction('test.pdf')
-      assertEquals(typeof result, 'string')
-      assertNotEquals(result, '')
+      if (entry) {
+        const result = entry.promptFunction('test.pdf')
+        assertEquals(typeof result, 'string')
+        assertNotEquals(result, '')
+      }
     })
 
     it('プロンプト関数にファイル名が含まれる', () => {
       const entry = getPrompt('NOHARA_G')
       assertExists(entry)
-      const fileName = 'specific_test_file.pdf'
-      const result = entry.promptFunction(fileName)
-      // プロンプトにファイル名が含まれることを確認
-      // （実際のプロンプト実装によっては調整が必要）
-      assertEquals(result.includes(fileName), true)
+      if (entry) {
+        const fileName = 'specific_test_file.pdf'
+        const result = entry.promptFunction(fileName)
+        // プロンプトにファイル名が含まれることを確認
+        // （実際のプロンプト実装によっては調整が必要）
+        assertEquals(result.includes(fileName), true)
+      }
     })
   })
 

--- a/supabase/import_map.test.json
+++ b/supabase/import_map.test.json
@@ -3,7 +3,9 @@
     "@google/genai": "./functions/mocks/google-genai.ts",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.44.4",
     "@std/testing/": "https://deno.land/std@0.224.0/testing/",
+    "@std/testing/asserts": "https://deno.land/std@0.224.0/testing/asserts.ts",
     "@std/testing/bdd": "https://deno.land/std@0.224.0/testing/bdd.ts",
+    "@std/testing/mock": "https://deno.land/std@0.224.0/testing/mock.ts",
     "https://deno.land/std@0.224.0/encoding/base64.ts": "https://deno.land/std@0.224.0/encoding/base64.ts"
   }
 }


### PR DESCRIPTION
## 概要
- GitHub ActionsでのDenoテスト実行時のエラーを修正
- TypeScriptの型エラーを解消し、import map設定を適切に構成

## 変更内容
1. **import_map.test.jsonの更新**
   - `@std/testing/asserts`と`@std/testing/mock`のマッピングを追加
   - これによりテストファイルでのインポートエラーを解消

2. **promptRegistry.test.tsの型エラー修正**
   - `assertExists`の後に型ガード（if文）を追加
   - TypeScriptコンパイラが`undefined`の可能性を認識できるように修正

3. **deno.jsonの非推奨オプション削除**
   - `compilerOptions.allowJs`を削除（Deno 2.xで非推奨）

## テスト
- ローカル環境でのテスト実行コマンド:
  ```bash
  cd supabase/functions
  deno test --import-map ../import_map.test.json
  ```

## チェックリスト
- [x] TypeScriptインポートエラーを修正
- [x] 型エラーを解消
- [x] 非推奨オプションを削除
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)