### PR TITLE
fix: DenoテストのCI/CD統合とエラー修正を包括的に実施

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,8 @@ jobs:
         run: |
           cd supabase/functions
           deno check **/*.ts || true
+      
+      - name: Run Supabase Functions tests
+        run: |
+          cd supabase/functions
+          deno test --import-map ../import_map.test.json

--- a/supabase/deno.json
+++ b/supabase/deno.json
@@ -23,7 +23,6 @@
   },
   "compilerOptions": {
     "lib": ["deno.window"],
-    "allowJs": true,
     "strict": true
   },
   "imports": {
@@ -38,8 +37,8 @@
     "exclude": ["functions/*/node_modules"]
   },
   "tasks": {
-    "test": "deno test --allow-net=supabase.co,googleapis.com --allow-env --allow-read",
-    "test:watch": "deno test --allow-net=supabase.co,googleapis.com --allow-env --allow-read --watch",
-    "test:coverage": "deno test --allow-net=supabase.co,googleapis.com --allow-env --allow-read --coverage"
+    "test": "deno test --import-map=import_map.test.json --allow-net=supabase.co,googleapis.com --allow-env --allow-read",
+    "test:watch": "deno test --import-map=import_map.test.json --allow-net=supabase.co,googleapis.com --allow-env --allow-read --watch",
+    "test:coverage": "deno test --import-map=import_map.test.json --allow-net=supabase.co,googleapis.com --allow-env --allow-read --coverage"
   }
 }

--- a/supabase/functions/process-pdf-single/__tests__/promptRegistry.test.ts
+++ b/supabase/functions/process-pdf-single/__tests__/promptRegistry.test.ts
@@ -8,19 +8,23 @@ describe('promptRegistry', () => {
     it('NOHARA_Gエントリが正しく設定されている', () => {
       const entry = PROMPT_REGISTRY['NOHARA_G']
       assertExists(entry)
-      assertEquals(entry.companyName, '野原G住環境')
-      assertEquals(entry.version, 'V20250526')
-      assertExists(entry.promptFunction)
-      assertEquals(typeof entry.promptFunction, 'function')
+      if (entry) {
+        assertEquals(entry.companyName, '野原G住環境')
+        assertEquals(entry.version, 'V20250526')
+        assertExists(entry.promptFunction)
+        assertEquals(typeof entry.promptFunction, 'function')
+      }
     })
 
     it('KATOUBENIYA_MISAWAエントリが正しく設定されている', () => {
       const entry = PROMPT_REGISTRY['KATOUBENIYA_MISAWA']
       assertExists(entry)
-      assertEquals(entry.companyName, '加藤ベニヤ池袋_ミサワホーム')
-      assertEquals(entry.version, 'V20250526')
-      assertExists(entry.promptFunction)
-      assertEquals(typeof entry.promptFunction, 'function')
+      if (entry) {
+        assertEquals(entry.companyName, '加藤ベニヤ池袋_ミサワホーム')
+        assertEquals(entry.version, 'V20250526')
+        assertExists(entry.promptFunction)
+        assertEquals(typeof entry.promptFunction, 'function')
+      }
     })
 
     it('各エントリが必要なプロパティを持っている', () => {
@@ -68,27 +72,33 @@ describe('promptRegistry', () => {
     it('NOHARA_Gのプロンプト関数がファイル名を受け取り文字列を返す', () => {
       const entry = getPrompt('NOHARA_G')
       assertExists(entry)
-      const result = entry.promptFunction('test.pdf')
-      assertEquals(typeof result, 'string')
-      assertNotEquals(result, '')
+      if (entry) {
+        const result = entry.promptFunction('test.pdf')
+        assertEquals(typeof result, 'string')
+        assertNotEquals(result, '')
+      }
     })
 
     it('KATOUBENIYA_MISAWAのプロンプト関数がファイル名を受け取り文字列を返す', () => {
       const entry = getPrompt('KATOUBENIYA_MISAWA')
       assertExists(entry)
-      const result = entry.promptFunction('test.pdf')
-      assertEquals(typeof result, 'string')
-      assertNotEquals(result, '')
+      if (entry) {
+        const result = entry.promptFunction('test.pdf')
+        assertEquals(typeof result, 'string')
+        assertNotEquals(result, '')
+      }
     })
 
     it('プロンプト関数にファイル名が含まれる', () => {
       const entry = getPrompt('NOHARA_G')
       assertExists(entry)
-      const fileName = 'specific_test_file.pdf'
-      const result = entry.promptFunction(fileName)
-      // プロンプトにファイル名が含まれることを確認
-      // （実際のプロンプト実装によっては調整が必要）
-      assertEquals(result.includes(fileName), true)
+      if (entry) {
+        const fileName = 'specific_test_file.pdf'
+        const result = entry.promptFunction(fileName)
+        // プロンプトにファイル名が含まれることを確認
+        // （実際のプロンプト実装によっては調整が必要）
+        assertEquals(result.includes(fileName), true)
+      }
     })
   })
 

--- a/supabase/functions/process-pdf-single/deno.json
+++ b/supabase/functions/process-pdf-single/deno.json
@@ -2,5 +2,10 @@
   "imports": {
     "@google/genai": "npm:@google/genai@^0.14.0",
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
+  },
+  "tasks": {
+    "test": "deno test --import-map=../../import_map.test.json --allow-net=supabase.co,googleapis.com --allow-env --allow-read __tests__/",
+    "test:watch": "deno test --import-map=../../import_map.test.json --allow-net=supabase.co,googleapis.com --allow-env --allow-read --watch __tests__/",
+    "test:coverage": "deno test --import-map=../../import_map.test.json --allow-net=supabase.co,googleapis.com --allow-env --allow-read --coverage __tests__/"
   }
 }

--- a/supabase/import_map.test.json
+++ b/supabase/import_map.test.json
@@ -1,8 +1,11 @@
 {
   "imports": {
-    "@google/genai": "./functions/mocks/google-genai.ts",
+    "@google/genai": "./functions/_shared/mocks/google-genai.ts",
     "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.44.4",
-    "@std/testing/": "https://deno.land/std@0.224.0/testing/",
+    "@std/testing": "https://deno.land/std@0.224.0/testing/bdd.ts",
+    "@std/testing/asserts": "https://deno.land/std@0.224.0/testing/asserts.ts",
+    "@std/testing/bdd": "https://deno.land/std@0.224.0/testing/bdd.ts",
+    "@std/testing/mock": "https://deno.land/std@0.224.0/testing/mock.ts",
     "https://deno.land/std@0.224.0/encoding/base64.ts": "https://deno.land/std@0.224.0/encoding/base64.ts"
   }
 }


### PR DESCRIPTION
## 概要
- GitHub ActionsでのDenoテスト実行時のエラーを包括的に修正
- CI/CDパイプラインにテスト実行を統合し、自動化を完成

## 変更内容

### 1. GitHub Actions CI/CDの統合
- `ci.yml`にSupabase Edge FunctionsのDenoテスト実行ステップを追加
- `deno test --import-map ../import_map.test.json`でテストを実行

### 2. import_map.test.jsonの最適化
- `@std/testing/bdd`マッピングを追加してBDD形式のテストを正しく解決
- テスト時の依存関係解決を完全に分離

### 3. promptRegistry.test.tsの型安全性向上
- `assertExists`の後に型ガード（if文）を追加
- TypeScriptコンパイラの`undefined`可能性エラーを完全解消

### 4. deno.jsonの現代化
- 非推奨の`compilerOptions.allowJs`を削除
- Deno 2.x標準に準拠

## テスト
実行されるコマンド:
```bash
cd supabase/functions
deno test --import-map ../import_map.test.json
```

## 影響範囲
- ✅ GitHub ActionsでのDenoテストが正常実行
- ✅ ローカル開発環境でのテスト実行も改善
- ✅ 型安全性の向上
- ❌ 破壊的変更なし

## チェックリスト
- [x] CI/CDパイプラインにテスト統合
- [x] import mapの最適化
- [x] TypeScript型エラーの解消
- [x] 非推奨設定の削除
- [x] テスト実行の自動化

🤖 Generated with [Claude Code](https://claude.ai/code)