### PR TITLE
fix: 生成文言パネルにスクロール機能を追加

### DIFF
--- a/frontend/src/components/workOrderTool/GeneratedTextPanel.tsx
+++ b/frontend/src/components/workOrderTool/GeneratedTextPanel.tsx
@@ -112,7 +112,7 @@ export const GeneratedTextPanel: React.FC<GeneratedTextPanelProps> = ({
   };
 
   return (
-    <div className="w-1/2 p-4 flex flex-col overflow-hidden">
+    <div className="w-1/2 p-4 flex flex-col min-h-0">
       <div className="mb-2 flex items-center justify-between">
         <h2 className="text-lg font-semibold">
           業務手配書 文言
@@ -205,7 +205,7 @@ export const GeneratedTextPanel: React.FC<GeneratedTextPanelProps> = ({
         )}
 
         <Textarea
-          className={`flex-1 resize-none rounded-md text-sm font-mono ${
+          className={`flex-1 resize-none rounded-md text-sm font-mono overflow-auto min-h-0 ${
             isEditMode
               ? 'border-orange-300 focus:border-orange-500 bg-orange-50/30'
               : editedText


### PR DESCRIPTION
## 概要

生成文言パネルで長いテキストがスクロールできない問題を修正しました。

## 変更内容

- メインコンテナの `overflow-hidden` を `min-h-0` に変更
- Textareaに `overflow-auto` と `min-h-0` を追加
- 長いテキストでも全ての内容を確認できるように改善

Fixes #113

生成されたGenerated with [Claude Code](https://claude.ai/code)