### PR TITLE
devブランチをmainにマージ - 作業指示書ツールの機能強化

### DIFF
--- a/frontend/src/components/workOrderTool/BatchHistoryPanel.tsx
+++ b/frontend/src/components/workOrderTool/BatchHistoryPanel.tsx
@@ -1,0 +1,218 @@
+// src/components/workOrderTool/BatchHistoryPanel.tsx
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { getBatchProcessHistory } from '@/lib/api';
+
+interface BatchProcess {
+  id: string;
+  status: string;
+  total_files: number;
+  processed_files: number;
+  failed_files: number;
+  company_id?: string;
+  auto_detect_enabled: boolean;
+  started_at: string;
+  completed_at?: string;
+  batch_process_files?: Array<{
+    id: string;
+    file_name: string;
+    status: string;
+    error_message?: string;
+    processing_time_ms?: number;
+    company_id?: string;
+    work_order_id?: string;
+  }>;
+}
+
+export const BatchHistoryPanel: React.FC = () => {
+  const [history, setHistory] = useState<BatchProcess[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedBatch, setExpandedBatch] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadHistory();
+  }, []);
+
+  const loadHistory = async () => {
+    try {
+      setLoading(true);
+      const data = await getBatchProcessHistory(20);
+      setHistory(data || []);
+    } catch (error) {
+      console.error('バッチ履歴の読み込みエラー:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case 'completed':
+        return <Badge className="bg-green-500">完了</Badge>;
+      case 'processing':
+        return <Badge className="bg-blue-500">処理中</Badge>;
+      case 'cancelled':
+        return <Badge variant="outline">キャンセル</Badge>;
+      case 'error':
+        return <Badge variant="destructive">エラー</Badge>;
+      default:
+        return <Badge>{status}</Badge>;
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const formatDuration = (start: string, end?: string) => {
+    if (!end) return '-';
+    const duration = new Date(end).getTime() - new Date(start).getTime();
+    const minutes = Math.floor(duration / 60000);
+    const seconds = Math.floor((duration % 60000) / 1000);
+    return `${minutes}分${seconds}秒`;
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="p-8 text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
+          <p className="mt-4 text-muted-foreground">履歴を読み込み中...</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle>一括処理履歴</CardTitle>
+          <Button size="sm" variant="outline" onClick={loadHistory}>
+            更新
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        <ScrollArea className="h-[600px]">
+          <div className="p-4">
+            {history.length === 0 ? (
+              <p className="text-center text-muted-foreground py-8">
+                一括処理の履歴がありません
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {history.map((batch) => (
+                  <div
+                    key={batch.id}
+                    className="border rounded-lg p-4 hover:bg-muted/50 transition-colors"
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        {getStatusBadge(batch.status)}
+                        <span className="text-sm font-medium">
+                          {batch.total_files}個のファイル
+                        </span>
+                        {batch.auto_detect_enabled && (
+                          <Badge variant="secondary" className="text-xs">
+                            自動判定
+                          </Badge>
+                        )}
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() =>
+                          setExpandedBatch(
+                            expandedBatch === batch.id ? null : batch.id
+                          )
+                        }
+                      >
+                        {expandedBatch === batch.id ? '詳細を隠す' : '詳細を表示'}
+                      </Button>
+                    </div>
+
+                    <div className="text-sm text-muted-foreground">
+                      <div className="flex gap-4">
+                        <span>開始: {formatDate(batch.started_at)}</span>
+                        {batch.completed_at && (
+                          <span>
+                            処理時間: {formatDuration(batch.started_at, batch.completed_at)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1">
+                        成功: {batch.processed_files - batch.failed_files}件、
+                        失敗: {batch.failed_files}件
+                      </div>
+                    </div>
+
+                    {expandedBatch === batch.id && batch.batch_process_files && (
+                      <div className="mt-4 border-t pt-4">
+                        <h4 className="text-sm font-semibold mb-2">ファイル詳細</h4>
+                        <div className="space-y-2">
+                          {batch.batch_process_files.map((file) => (
+                            <div
+                              key={file.id}
+                              className="flex items-center justify-between text-sm p-2 rounded bg-muted/30"
+                            >
+                              <div className="flex items-center gap-2">
+                                <span className="truncate max-w-[200px]">
+                                  {file.file_name}
+                                </span>
+                                {file.status === 'success' ? (
+                                  <Badge className="bg-green-500 text-xs">成功</Badge>
+                                ) : file.status === 'error' ? (
+                                  <Badge variant="destructive" className="text-xs">
+                                    エラー
+                                  </Badge>
+                                ) : (
+                                  <Badge variant="secondary" className="text-xs">
+                                    {file.status}
+                                  </Badge>
+                                )}
+                              </div>
+                              {file.processing_time_ms && (
+                                <span className="text-xs text-muted-foreground">
+                                  {Math.round(file.processing_time_ms / 1000)}秒
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                        {batch.batch_process_files.some((f) => f.error_message) && (
+                          <div className="mt-3 p-3 bg-red-50 dark:bg-red-900/20 rounded">
+                            <h5 className="text-xs font-semibold text-red-600 dark:text-red-400 mb-1">
+                              エラー詳細
+                            </h5>
+                            {batch.batch_process_files
+                              .filter((f) => f.error_message)
+                              .map((file) => (
+                                <p key={file.id} className="text-xs text-red-600 dark:text-red-400">
+                                  {file.file_name}: {file.error_message}
+                                </p>
+                              ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/components/workOrderTool/BatchProgressPanel.tsx
+++ b/frontend/src/components/workOrderTool/BatchProgressPanel.tsx
@@ -1,0 +1,182 @@
+// src/components/workOrderTool/BatchProgressPanel.tsx
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { BatchProcessingState, BatchProcessResult } from '@/types';
+
+interface BatchProgressPanelProps {
+  batchState: BatchProcessingState;
+  onCancel?: () => void;
+  progress: number;
+  elapsedTime: number;
+}
+
+export const BatchProgressPanel: React.FC<BatchProgressPanelProps> = ({
+  batchState,
+  onCancel,
+  progress,
+  elapsedTime,
+}) => {
+  const formatTime = (ms: number): string => {
+    const seconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+
+    if (hours > 0) {
+      return `${hours}時間${minutes % 60}分${seconds % 60}秒`;
+    } else if (minutes > 0) {
+      return `${minutes}分${seconds % 60}秒`;
+    } else {
+      return `${seconds}秒`;
+    }
+  };
+
+  const getStatusBadge = (status: BatchProcessResult['status']) => {
+    switch (status) {
+      case 'success':
+        return <Badge className="bg-green-500">成功</Badge>;
+      case 'error':
+        return <Badge variant="destructive">エラー</Badge>;
+      case 'processing':
+        return <Badge className="bg-blue-500">処理中</Badge>;
+      case 'pending':
+        return <Badge variant="secondary">待機中</Badge>;
+      case 'cancelled':
+        return <Badge variant="outline">キャンセル</Badge>;
+      default:
+        return <Badge>{status}</Badge>;
+    }
+  };
+
+  const successCount = batchState.results.filter(r => r.status === 'success').length;
+  const errorCount = batchState.results.filter(r => r.status === 'error').length;
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>一括処理進捗</span>
+          <div className="flex gap-2">
+            {batchState.isProcessing && (
+              <Button size="sm" variant="destructive" onClick={onCancel}>
+                キャンセル
+              </Button>
+            )}
+            {!batchState.isProcessing && batchState.results.length > 0 && (
+              <Button size="sm" variant="secondary" disabled>
+                完了
+              </Button>
+            )}
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {/* 進捗バー */}
+        <div className="mb-4">
+          <div className="flex justify-between text-sm mb-1">
+            <span>
+              {batchState.results.length} / {batchState.totalFiles || 0} ファイル
+            </span>
+            <span>{progress}%</span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+            <div 
+              className="bg-blue-600 h-2.5 rounded-full transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        {/* 統計情報 */}
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-green-600">{successCount}</div>
+            <div className="text-sm text-muted-foreground">成功</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-red-600">{errorCount}</div>
+            <div className="text-sm text-muted-foreground">エラー</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-blue-600">
+              {formatTime(elapsedTime)}
+            </div>
+            <div className="text-sm text-muted-foreground">処理時間</div>
+          </div>
+        </div>
+
+        {/* 処理結果リスト */}
+        <div className="border rounded-lg">
+          <div className="p-2 bg-muted">
+            <h4 className="text-sm font-semibold">処理結果</h4>
+          </div>
+          <ScrollArea className="h-64">
+            <div className="p-2">
+              {batchState.results.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-4">
+                  処理結果がまだありません
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {batchState.results.map((result, index) => (
+                    <li 
+                      key={`${result.fileName}-${index}`}
+                      className="flex items-center justify-between p-2 rounded hover:bg-muted"
+                    >
+                      <div className="flex items-center gap-2 flex-1">
+                        <span className="text-sm truncate">{result.fileName}</span>
+                        {getStatusBadge(result.status)}
+                      </div>
+                      {result.processingTime && (
+                        <span className="text-xs text-muted-foreground">
+                          {formatTime(result.processingTime)}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* エラー詳細 */}
+        {errorCount > 0 && (
+          <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 rounded-lg">
+            <h4 className="text-sm font-semibold text-red-600 dark:text-red-400 mb-2">
+              エラー詳細
+            </h4>
+            <ul className="space-y-1">
+              {batchState.results
+                .filter(r => r.status === 'error')
+                .map((result, index) => (
+                  <li key={`error-${result.fileName}-${index}`} className="text-xs">
+                    <span className="font-medium">{result.fileName}:</span>{' '}
+                    <span className="text-red-600 dark:text-red-400">
+                      {result.errorMessage || '不明なエラー'}
+                    </span>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        )}
+
+        {/* 現在処理中のファイル */}
+        {batchState.isProcessing && (
+          <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+            <div className="flex items-center gap-2">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+              <span className="text-sm">
+                処理中: {batchState.results.find(r => r.status === 'processing')?.fileName || 
+                        `${(batchState.currentFileIndex || 0) + 1}番目のファイル`}
+              </span>
+            </div>
+          </div>
+        )}
+
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/components/workOrderTool/GeneratedTextPanel.tsx
+++ b/frontend/src/components/workOrderTool/GeneratedTextPanel.tsx
@@ -7,7 +7,6 @@ import { updateWorkOrderEditedText } from '@/lib/api';
 import type {
   ProcessedCompanyInfo,
   PdfFile,
-  CompanyOptionValue,
   CompanyDetectionResult,
   ProcessState,
 } from '@/types';
@@ -18,7 +17,6 @@ interface GeneratedTextPanelProps {
   isLoading: boolean; // AI処理中か
   processingFile: PdfFile | null; // AI処理中のファイル (プレースホルダー用)
   pdfFileToDisplayForPlaceholder: PdfFile | null; // プレビュー中のファイル (プレースホルダー用)
-  selectedCompanyIdForPlaceholder: CompanyOptionValue; // 選択中の会社 (プレースホルダー用)
   processedCompanyInfo: ProcessedCompanyInfo; // 表示ヘッダー用 (ファイル名、会社名)
   lastDetectionResult?: CompanyDetectionResult | null; // 自動判定結果
   onRequestFeedback?: () => void; // フィードバックモーダルを開く
@@ -35,7 +33,6 @@ export const GeneratedTextPanel: React.FC<GeneratedTextPanelProps> = ({
   isLoading,
   processingFile,
   pdfFileToDisplayForPlaceholder,
-  selectedCompanyIdForPlaceholder,
   processedCompanyInfo,
   lastDetectionResult,
   onRequestFeedback,
@@ -103,10 +100,7 @@ export const GeneratedTextPanel: React.FC<GeneratedTextPanelProps> = ({
       return ''; // 生成テキストがあればプレースホルダーは不要
     }
     if (pdfFileToDisplayForPlaceholder) {
-      if (selectedCompanyIdForPlaceholder) {
-        return `「${pdfFileToDisplayForPlaceholder.name}」の処理結果がここに表示されます。\nAI処理が完了するまでお待ちください。`;
-      }
-      return `「${pdfFileToDisplayForPlaceholder.name}」の処理結果がここに表示されます。\n会社を選択し、リストのファイルをクリックして処理を開始してください。`;
+      return `「${pdfFileToDisplayForPlaceholder.name}」をプレビュー中です。\n\n処理結果を表示するには、AI実行ボタンを押して処理を開始してください。`;
     }
     return '処理するPDFを左の一覧から選択するか、新しいPDFをアップロードしてください。';
   };

--- a/frontend/src/hooks/useBatchProcessor.ts
+++ b/frontend/src/hooks/useBatchProcessor.ts
@@ -1,0 +1,595 @@
+// src/hooks/useBatchProcessor.ts
+import { useState, useCallback, useRef } from 'react';
+import { toast } from 'sonner';
+import {
+  createBatchProcess,
+  recordBatchProcessFile,
+  updateBatchProcessFile,
+  updateBatchProcessStatus,
+} from '@/lib/api';
+import type {
+  BatchProcessingState,
+  BatchProcessResult,
+  BatchProcessOptions,
+  PdfFile,
+  CompanyOptionValue,
+  CompanyDetectionResult,
+} from '@/types';
+
+interface UseBatchProcessorProps {
+  processFile: (
+    fileToProcess: File,
+    companyId: CompanyOptionValue,
+    companyLabelForError: string,
+    enableAutoDetection?: boolean,
+    ocrOnly?: boolean
+  ) => Promise<{ success: boolean; errorMessage?: string }>;
+  onFileProcessed?: (result: BatchProcessResult) => void;
+  onBatchComplete?: (results: BatchProcessResult[]) => void;
+  getCompanyLabel?: (companyId: CompanyOptionValue) => string;
+  getLastProcessResult?: () => { workOrderId?: string; detectionResult?: CompanyDetectionResult } | null;
+}
+
+export const useBatchProcessor = ({
+  processFile,
+  onFileProcessed,
+  onBatchComplete,
+  getCompanyLabel = (id) => id,
+  getLastProcessResult,
+}: UseBatchProcessorProps) => {
+  const [batchState, setBatchState] = useState<BatchProcessingState>({
+    isProcessing: false,
+    processedCount: 0,
+    totalCount: 0,
+    successCount: 0,
+    errorCount: 0,
+    currentFileIndex: 0,
+    totalFiles: 0,
+    processedFiles: 0,
+    failedFiles: 0,
+    results: [],
+  });
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const batchProcessIdRef = useRef<string | null>(null);
+
+  // バッチ処理の開始
+  const startBatchProcess = useCallback(
+    async (
+      files: PdfFile[],
+      options: BatchProcessOptions = {}
+    ) => {
+      const {
+        companyId = '',
+        autoDetectEnabled = false,
+        concurrentLimit = 1, // デフォルトは1つずつ処理
+        pauseOnError = false,
+      } = options;
+
+      if (files.length === 0) {
+        toast.error('処理するファイルが選択されていません');
+        return;
+      }
+
+      // パフォーマンスのため、大量ファイルの処理には制限を設ける
+      if (files.length > 50) {
+        toast.warning('一度に処理できるファイルは50個までです。ファイルを分割して処理してください。');
+        return;
+      }
+
+      try {
+        // バッチ処理をデータベースに作成
+        const batchProcess = await createBatchProcess(files.length, options);
+        batchProcessIdRef.current = batchProcess.id;
+
+        // 各ファイルをデータベースに記録
+        await Promise.all(
+          files.map(file => 
+            recordBatchProcessFile(batchProcess.id, file.name, file.size)
+          )
+        );
+
+        // 処理開始
+        setBatchState({
+          isProcessing: true,
+          processedCount: 0,
+          totalCount: files.length,
+          successCount: 0,
+          errorCount: 0,
+          currentFileIndex: 0,
+          totalFiles: files.length,
+          processedFiles: 0,
+          failedFiles: 0,
+          results: [],
+          startTime: new Date(),
+        });
+
+        abortControllerRef.current = new AbortController();
+
+        toast.info(`${files.length}個のファイルの処理を開始します`);
+
+      const results: BatchProcessResult[] = [];
+
+      // 並行処理のヘルパー関数
+      const processFileWithResult = async (
+        file: PdfFile,
+        index: number
+      ): Promise<BatchProcessResult> => {
+        if (abortControllerRef.current?.signal.aborted) {
+          return {
+            fileName: file.name,
+            status: 'cancelled',
+            errorMessage: '処理がキャンセルされました',
+          };
+        }
+
+        const startedAt = new Date();
+        
+        // 現在の処理ファイルを更新
+        setBatchState(prev => ({
+          ...prev,
+          currentFileIndex: index,
+        }));
+
+        try {
+          let actualResult: { workOrderId?: string; detectionResult?: CompanyDetectionResult } = { workOrderId: undefined, detectionResult: undefined };
+          
+          // 2段階処理の場合
+          if (autoDetectEnabled) {
+            // バッチ処理でのAPI負荷軽減のため、ファイル間に待機時間を追加
+            if (index > 0) {
+              console.log(`[useBatchProcessor] API負荷軽減のため1秒待機: ${file.name}`);
+              await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+            
+            // Stage 1: OCR + 会社判定
+            const stage1ProcessResult = await processFile(
+              file,
+              '',
+              'OCR処理',
+              true,
+              true
+            );
+            
+            // Stage 1でエラーが発生した場合
+            if (!stage1ProcessResult.success) {
+              console.error(`[useBatchProcessor] Stage 1エラー: ${file.name}`, stage1ProcessResult.errorMessage);
+              const completedAt = new Date();
+              
+              return {
+                fileName: file.name,
+                status: 'error' as const,
+                errorMessage: `OCR処理に失敗しました: ${stage1ProcessResult.errorMessage}`,
+                processingTime: completedAt.getTime() - startedAt.getTime(),
+                startedAt,
+                completedAt,
+              };
+            }
+            
+            // Stage 1完了後、少し待機してからlastProcessResultRefを確認
+            await new Promise(resolve => setTimeout(resolve, 500));
+            
+            // Stage 1の結果を取得
+            const stage1Result = getLastProcessResult?.();
+            console.log(`[useBatchProcessor] Stage 1結果確認: ${file.name}`, {
+              stage1Result: stage1Result,
+              detectionResult: stage1Result?.detectionResult,
+              detectedCompanyId: stage1Result?.detectionResult?.detectedCompanyId,
+              confidence: stage1Result?.detectionResult?.confidence,
+            });
+            
+            if (stage1Result?.detectionResult?.detectedCompanyId) {
+              const detectedCompanyId = stage1Result.detectionResult.detectedCompanyId;
+              const companyLabel = getCompanyLabel(detectedCompanyId);
+              
+              console.log(`[useBatchProcessor] Stage 2開始: ${file.name} (会社: ${companyLabel})`);
+              
+              try {
+                // Stage 1とStage 2の間にも待機時間を追加（API負荷軽減）
+                console.log(`[useBatchProcessor] Stage 1→2間で1秒待機: ${file.name}`);
+                await new Promise(resolve => setTimeout(resolve, 1000));
+                
+                // Stage 2: 手配書作成
+                const stage2ProcessResult = await processFile(
+                  file,
+                  detectedCompanyId,
+                  companyLabel,
+                  false, // enableAutoDetection = false (判定は完了済み)
+                  false // ocrOnly = false (手配書作成を実行)
+                );
+                
+                // Stage 2でエラーが発生した場合
+                if (!stage2ProcessResult.success) {
+                  throw new Error(`手配書作成に失敗しました: ${stage2ProcessResult.errorMessage}`);
+                }
+                
+                // Stage 2完了後、再度結果を取得
+                await new Promise(resolve => setTimeout(resolve, 500));
+                actualResult = getLastProcessResult?.() || actualResult;
+                
+                // Stage 2が成功したかチェック
+                if (!actualResult.workOrderId) {
+                  throw new Error('手配書作成でwork_orderが作成されませんでした');
+                }
+              } catch (stage2Error) {
+                console.error(`[useBatchProcessor] Stage 2エラー: ${file.name}`, stage2Error);
+                const completedAt = new Date();
+                
+                const stage2ErrorResult = {
+                  fileName: file.name,
+                  status: 'error' as const,
+                  errorMessage: `手配書作成に失敗しました: ${stage2Error instanceof Error ? stage2Error.message : String(stage2Error)}`,
+                  processingTime: completedAt.getTime() - startedAt.getTime(),
+                  startedAt,
+                  completedAt,
+                };
+                
+                console.log(`[useBatchProcessor] Stage 2エラー結果を作成:`, {
+                  fileName: stage2ErrorResult.fileName,
+                  status: stage2ErrorResult.status,
+                  errorMessage: stage2ErrorResult.errorMessage,
+                });
+                
+                // バッチ状態を更新
+                setBatchState(prev => ({
+                  ...prev,
+                  processedCount: prev.processedCount + 1,
+                  errorCount: prev.errorCount + 1,
+                  failedFiles: (prev.failedFiles || 0) + 1,
+                  results: [...prev.results, stage2ErrorResult],
+                }));
+                
+                // Stage 2エラーもDBに記録
+                if (batchProcessIdRef.current) {
+                  try {
+                    console.log(`[useBatchProcessor] ${file.name}のStage 2エラー状態をDBに記録中...`);
+                    await updateBatchProcessFile(batchProcessIdRef.current, file.name, stage2ErrorResult);
+                    console.log(`[useBatchProcessor] ${file.name}のStage 2エラー状態をDBに記録完了`);
+                  } catch (dbError) {
+                    console.error(`[useBatchProcessor] ${file.name}のStage 2エラーDB記録に失敗:`, dbError);
+                  }
+                }
+                
+                // onFileProcessedコールバックを確実に呼び出す
+                try {
+                  console.log(`[useBatchProcessor] Stage 2エラーでonFileProcessedコールバック呼び出し: ${file.name}`);
+                  onFileProcessed?.(stage2ErrorResult);
+                  console.log(`[useBatchProcessor] Stage 2エラーでonFileProcessedコールバック完了: ${file.name}`);
+                } catch (callbackError) {
+                  console.error(`[useBatchProcessor] Stage 2エラーでonFileProcessedコールバックエラー:`, callbackError);
+                }
+                
+                return stage2ErrorResult;
+              }
+            } else {
+              // 会社判定に失敗した場合は、エラーとして記録するが処理は継続
+              const detectionDetails = stage1Result?.detectionResult;
+              const errorDetails = detectionDetails ? 
+                `信頼度: ${detectionDetails.confidence}, 検出キーワード: ${detectionDetails.details?.foundKeywords?.join(', ') || 'なし'}` :
+                'OCR処理の結果が取得できませんでした';
+                
+              console.warn(`[useBatchProcessor] 会社判定に失敗: ${file.name}`, {
+                detectionResult: detectionDetails,
+                errorDetails,
+              });
+              
+              const completedAt = new Date();
+              
+              const detectionErrorResult = {
+                fileName: file.name,
+                status: 'error' as const,
+                errorMessage: `会社の自動判定に失敗しました。${errorDetails}`,
+                processingTime: completedAt.getTime() - startedAt.getTime(),
+                startedAt,
+                completedAt,
+              };
+              
+              console.log(`[useBatchProcessor] 会社判定エラー結果を作成:`, {
+                fileName: detectionErrorResult.fileName,
+                status: detectionErrorResult.status,
+                errorMessage: detectionErrorResult.errorMessage,
+              });
+              
+              // バッチ状態を更新
+              setBatchState(prev => ({
+                ...prev,
+                processedCount: prev.processedCount + 1,
+                errorCount: prev.errorCount + 1,
+                failedFiles: (prev.failedFiles || 0) + 1,
+                results: [...prev.results, detectionErrorResult],
+              }));
+              
+              // 会社判定失敗もDBに記録
+              if (batchProcessIdRef.current) {
+                try {
+                  console.log(`[useBatchProcessor] ${file.name}の会社判定失敗状態をDBに記録中...`);
+                  await updateBatchProcessFile(batchProcessIdRef.current, file.name, detectionErrorResult);
+                  console.log(`[useBatchProcessor] ${file.name}の会社判定失敗状態をDBに記録完了`);
+                } catch (dbError) {
+                  console.error(`[useBatchProcessor] ${file.name}の会社判定失敗DB記録に失敗:`, dbError);
+                }
+              }
+              
+              // onFileProcessedコールバックを確実に呼び出す
+              try {
+                console.log(`[useBatchProcessor] 会社判定エラーでonFileProcessedコールバック呼び出し: ${file.name}`);
+                onFileProcessed?.(detectionErrorResult);
+                console.log(`[useBatchProcessor] 会社判定エラーでonFileProcessedコールバック完了: ${file.name}`);
+              } catch (callbackError) {
+                console.error(`[useBatchProcessor] 会社判定エラーでonFileProcessedコールバックエラー:`, callbackError);
+              }
+              
+              return detectionErrorResult;
+            }
+          } else {
+            // 通常処理
+            // バッチ処理でのAPI負荷軽減のため、ファイル間に待機時間を追加
+            if (index > 0) {
+              console.log(`[useBatchProcessor] API負荷軽減のため1秒待機: ${file.name}`);
+              await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+            
+            const companyLabel = getCompanyLabel(companyId);
+            const normalProcessResult = await processFile(
+              file,
+              companyId,
+              companyLabel,
+              false,
+              false
+            );
+            
+            // 通常処理でエラーが発生した場合
+            if (!normalProcessResult.success) {
+              console.error(`[useBatchProcessor] 通常処理エラー: ${file.name}`, normalProcessResult.errorMessage);
+              const completedAt = new Date();
+              
+              return {
+                fileName: file.name,
+                status: 'error' as const,
+                errorMessage: `処理に失敗しました: ${normalProcessResult.errorMessage}`,
+                processingTime: completedAt.getTime() - startedAt.getTime(),
+                startedAt,
+                completedAt,
+              };
+            }
+            
+            // 処理完了後、結果を取得
+            await new Promise(resolve => setTimeout(resolve, 500));
+            actualResult = getLastProcessResult?.() || actualResult;
+          }
+
+          // 処理完了後にキャンセルされていないかチェック
+          if (abortControllerRef.current?.signal.aborted) {
+            return {
+              fileName: file.name,
+              status: 'cancelled',
+              errorMessage: '処理がキャンセルされました',
+              processingTime: new Date().getTime() - startedAt.getTime(),
+              startedAt,
+              completedAt: new Date(),
+            };
+          }
+
+          const completedAt = new Date();
+            
+          const result: BatchProcessResult = {
+            fileName: file.name,
+            status: 'success',
+            companyId: actualResult.detectionResult?.detectedCompanyId || companyId,
+            workOrderId: actualResult.workOrderId,
+            detectionResult: actualResult.detectionResult,
+            processingTime: completedAt.getTime() - startedAt.getTime(),
+            startedAt,
+            completedAt,
+          };
+
+          setBatchState(prev => ({
+            ...prev,
+            processedCount: prev.processedCount + 1,
+            successCount: prev.successCount + 1,
+            processedFiles: (prev.processedFiles || 0) + 1,
+            results: [...prev.results, result],
+          }));
+
+          // データベースに結果を記録
+          if (batchProcessIdRef.current) {
+            await updateBatchProcessFile(batchProcessIdRef.current, file.name, result);
+          }
+
+          onFileProcessed?.(result);
+          return result;
+
+        } catch (error) {
+          console.error(`[useBatchProcessor] ${file.name}の処理中にエラーが発生:`, error);
+          
+          const completedAt = new Date();
+          const errorMessage = error instanceof Error ? error.message : '不明なエラー';
+          
+          const result: BatchProcessResult = {
+            fileName: file.name,
+            status: 'error',
+            errorMessage,
+            processingTime: completedAt.getTime() - startedAt.getTime(),
+            startedAt,
+            completedAt,
+          };
+
+          console.log(`[useBatchProcessor] エラー結果を作成:`, {
+            fileName: result.fileName,
+            status: result.status,
+            errorMessage: result.errorMessage,
+            callbackAvailable: !!onFileProcessed,
+          });
+
+          setBatchState(prev => ({
+            ...prev,
+            processedCount: prev.processedCount + 1,
+            errorCount: prev.errorCount + 1,
+            failedFiles: (prev.failedFiles || 0) + 1,
+            results: [...prev.results, result],
+          }));
+
+          // データベースに結果を記録
+          if (batchProcessIdRef.current) {
+            try {
+              console.log(`[useBatchProcessor] ${file.name}のエラー状態をDBに記録中...`, {
+                batchProcessId: batchProcessIdRef.current,
+                fileName: file.name,
+                status: result.status,
+                errorMessage: result.errorMessage,
+              });
+              
+              await updateBatchProcessFile(batchProcessIdRef.current, file.name, result);
+              
+              console.log(`[useBatchProcessor] ${file.name}のエラー状態をDBに記録完了`);
+            } catch (dbError) {
+              console.error(`[useBatchProcessor] ${file.name}のDBエラー記録に失敗:`, dbError);
+              // DB更新エラーでもバッチ処理は継続
+            }
+          } else {
+            console.warn(`[useBatchProcessor] ${file.name}エラー時にbatchProcessIdが未設定`);
+          }
+
+          // onFileProcessedコールバックを確実に呼び出す
+          try {
+            console.log(`[useBatchProcessor] onFileProcessedコールバック呼び出し開始: ${file.name}`);
+            onFileProcessed?.(result);
+            console.log(`[useBatchProcessor] onFileProcessedコールバック呼び出し完了: ${file.name}`);
+          } catch (callbackError) {
+            console.error(`[useBatchProcessor] onFileProcessedコールバックでエラー:`, callbackError);
+          }
+
+          if (pauseOnError) {
+            // 一時停止機能削除により、エラー時は処理を停止
+            abortControllerRef.current?.abort();
+            toast.error(`エラーが発生したため処理を停止しました: ${file.name}`);
+          }
+
+          return result;
+        }
+      };
+
+      // 並行処理数に応じて処理を実行
+      if (concurrentLimit > 1) {
+        // 並行処理（メモリ効率を考慮して最大3並列に制限）
+        const effectiveConcurrentLimit = Math.min(concurrentLimit, 3);
+        const chunks: PdfFile[][] = [];
+        for (let i = 0; i < files.length; i += effectiveConcurrentLimit) {
+          chunks.push(files.slice(i, i + effectiveConcurrentLimit));
+        }
+
+        for (const chunk of chunks) {
+          if (abortControllerRef.current?.signal.aborted) break;
+          
+          const chunkResults = await Promise.all(
+            chunk.map((file) => 
+              processFileWithResult(file, files.indexOf(file))
+            )
+          );
+          results.push(...chunkResults);
+          
+          // メモリ解放のため、大量処理時は少し待機
+          if (files.length > 20 && chunks.length > 1) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+          }
+        }
+      } else {
+        // 順次処理
+        for (let i = 0; i < files.length; i++) {
+          if (abortControllerRef.current?.signal.aborted) break;
+          
+          const result = await processFileWithResult(files[i], i);
+          results.push(result);
+        }
+      }
+
+      // 処理完了
+      const endTime = new Date();
+      setBatchState(prev => ({
+        ...prev,
+        isProcessing: false,
+        endTime,
+        results,
+      }));
+
+      const successCount = results.filter(r => r.status === 'success').length;
+      const errorCount = results.filter(r => r.status === 'error').length;
+      const cancelledCount = results.filter(r => r.status === 'cancelled').length;
+
+      // データベースのバッチ処理ステータスを更新
+      if (batchProcessIdRef.current) {
+        const status = cancelledCount > 0 ? 'cancelled' : 
+                       errorCount === files.length ? 'error' : 
+                       'completed';
+        await updateBatchProcessStatus(
+          batchProcessIdRef.current,
+          status,
+          successCount + errorCount,
+          errorCount
+        );
+      }
+
+      if (cancelledCount > 0) {
+        toast.warning(
+          `一括処理を中断しました。成功: ${successCount}件、失敗: ${errorCount}件、キャンセル: ${cancelledCount}件`
+        );
+      } else {
+        toast.success(
+          `一括処理が完了しました。成功: ${successCount}件、失敗: ${errorCount}件`
+        );
+      }
+
+      onBatchComplete?.(results);
+
+      // ブラウザ通知
+      if ('Notification' in window && Notification.permission === 'granted') {
+        new Notification('MagIQ - 一括処理完了', {
+          body: `${files.length}個のファイルの処理が完了しました`,
+          icon: '/vite.svg',
+        });
+      }
+    } catch (error) {
+      console.error('バッチ処理の開始エラー:', error);
+      toast.error('一括処理の開始に失敗しました');
+      setBatchState(prev => ({ ...prev, isProcessing: false }));
+    }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [processFile, onFileProcessed, onBatchComplete, getCompanyLabel]
+  );
+
+
+  // バッチ処理のキャンセル
+  const cancelBatchProcess = useCallback(() => {
+    if (batchState.isProcessing) {
+      abortControllerRef.current?.abort();
+      setBatchState(prev => ({
+        ...prev,
+        isProcessing: false,
+        endTime: new Date(),
+      }));
+      toast.warning('一括処理をキャンセルしました');
+    }
+  }, [batchState.isProcessing]);
+
+  // 進捗率の計算
+  const getProgress = useCallback(() => {
+    if (!batchState.totalFiles || batchState.totalFiles === 0) return 0;
+    return Math.round((batchState.results.length / batchState.totalFiles) * 100);
+  }, [batchState.results.length, batchState.totalFiles]);
+
+  // 処理時間の計算
+  const getElapsedTime = useCallback(() => {
+    if (!batchState.startTime) return 0;
+    const endTime = batchState.endTime || new Date();
+    return endTime.getTime() - batchState.startTime.getTime();
+  }, [batchState.startTime, batchState.endTime]);
+
+  return {
+    batchState,
+    startBatchProcess,
+    cancelBatchProcess,
+    getProgress,
+    getElapsedTime,
+  };
+};

--- a/frontend/src/hooks/useFileHandler.ts
+++ b/frontend/src/hooks/useFileHandler.ts
@@ -38,6 +38,18 @@ export const useFileHandler = (): UseFileHandlerReturn => {
           });
           return;
         }
+        
+        // ファイルサイズ制限チェック（5MB）
+        const maxFileSize = 5 * 1024 * 1024; // 5MB in bytes
+        if (newFile.size > maxFileSize) {
+          const fileSizeMB = (newFile.size / (1024 * 1024)).toFixed(2);
+          toast.error(`ファイルサイズが制限を超えています: 「${newFile.name}」`, {
+            description: `ファイルサイズ: ${fileSizeMB}MB（制限: 5MB）`,
+            duration: 5000,
+          });
+          return;
+        }
+        
         const isDuplicate = uploadedFiles.some(
           (existingFile) =>
             existingFile.name === newFile.name &&

--- a/frontend/src/test/usePdfProcessor.test.ts
+++ b/frontend/src/test/usePdfProcessor.test.ts
@@ -385,7 +385,7 @@ describe('usePdfProcessor Hook', () => {
       expect(result.current.isLoading).toBe(false);
 
       // 処理開始
-      let processPromise: Promise<void>;
+      let processPromise: Promise<{ success: boolean; errorMessage?: string }>;
       await act(async () => {
         processPromise = result.current.processFile(
           mockFile,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -37,6 +37,7 @@ export interface PdfProcessSuccessResponse {
   ocrOnly?: boolean; // OCRのみの実行か
   detectionResult?: CompanyDetectionResult | null; // 自動判定結果
   dbRecordId?: string; // データベースレコードID
+  workOrderId?: string; // バッチ処理用のWork Order ID
   identifiedCompany?: string; // 特定された会社
   originalFileName?: string; // 元のファイル名
   promptUsedIdentifier?: string; // 使用されたプロンプト識別子
@@ -125,6 +126,7 @@ export interface ProcessedCompanyInfo {
   processedAt?: string;
   workOrderId?: string;
   file?: File; // 実際のファイル情報
+  status?: 'completed' | 'processing' | 'error' | 'pending'; // 処理ステータス
 }
 
 // Work Order関連の型定義
@@ -350,4 +352,41 @@ export interface WorkOrderStatusResponse {
     error_message?: string;
   };
   error?: string;
+}
+
+// バッチ処理関連の型定義
+export interface BatchProcessOptions {
+  companyId?: CompanyOptionValue;
+  autoDetectEnabled?: boolean;
+  concurrentLimit?: number;
+  pauseOnError?: boolean;
+  retryFailedFiles?: boolean;
+}
+
+export interface BatchProcessResult {
+  fileName: string;
+  status: 'success' | 'error' | 'cancelled' | 'processing' | 'pending';
+  workOrderId?: string;
+  errorMessage?: string;
+  processingTime?: number;
+  startedAt?: Date;
+  completedAt?: Date;
+  detectionResult?: CompanyDetectionResult;
+  companyId?: CompanyOptionValue;
+}
+
+export interface BatchProcessingState {
+  isProcessing: boolean;
+  processedCount: number;
+  totalCount: number;
+  successCount: number;
+  errorCount: number;
+  currentFile?: string;
+  currentFileIndex?: number;
+  results: BatchProcessResult[];
+  startTime?: Date;
+  endTime?: Date;
+  totalFiles?: number;
+  processedFiles?: number;
+  failedFiles?: number;
 }

--- a/supabase/functions/process-pdf-single/index.ts
+++ b/supabase/functions/process-pdf-single/index.ts
@@ -52,49 +52,70 @@ async function performOcrCompanyDetection(
   pdfBase64Data: string
 ): Promise<OcrDetectionResponse> {
   const genAI = new GoogleGenAI({ apiKey: geminiApiKey })
-
-  try {
-    const response = await genAI.models.generateContent({
-      model: 'gemini-2.5-flash-preview-04-17',
-      contents: [
-        {
-          role: 'user',
-          parts: [
-            { text: OCR_COMPANY_DETECTION_PROMPT },
-            {
-              inlineData: {
-                mimeType: pdfFile.type,
-                data: pdfBase64Data,
+  
+  const maxRetries = 3;
+  let attempt = 0;
+  
+  while (attempt < maxRetries) {
+    try {
+      console.log(`[OCR Detection] Gemini API呼び出し試行 ${attempt + 1}/${maxRetries}`);
+      
+      const response = await genAI.models.generateContent({
+        model: 'gemini-2.5-flash-preview-05-20',
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              { text: OCR_COMPANY_DETECTION_PROMPT },
+              {
+                inlineData: {
+                  mimeType: pdfFile.type,
+                  data: pdfBase64Data,
+                },
               },
-            },
-          ],
-        },
-      ],
-    })
+            ],
+          },
+        ],
+      })
 
-    const responseText = response.text || ''
-    console.log('[OCR Detection] Gemini raw response:', responseText)
+      const responseText = response.text || ''
+      console.log('[OCR Detection] Gemini raw response:', responseText)
 
-    // JSONレスポンスをパース
-    const jsonMatch = responseText.match(/\{[\s\S]*\}/)
-    if (!jsonMatch) {
-      throw new Error('No JSON found in OCR response')
+      // JSONレスポンスをパース
+      const jsonMatch = responseText.match(/\{[\s\S]*\}/)
+      if (!jsonMatch) {
+        throw new Error('No JSON found in OCR response')
+      }
+
+      const result = JSON.parse(jsonMatch[0]) as OcrDetectionResponse
+
+      // バリデーション
+      return {
+        company_id: result.company_id || null,
+        confidence: typeof result.confidence === 'number' ? result.confidence : 0,
+        detected_text: result.detected_text || '',
+        found_keywords: Array.isArray(result.found_keywords) ? result.found_keywords : [],
+        reasoning: result.reasoning || '',
+      }
+    } catch (error) {
+      attempt++;
+      console.error(`[OCR Detection] Gemini API呼び出し失敗 (試行 ${attempt}/${maxRetries}):`, error);
+      
+      // 最後の試行でない場合は待機してリトライ
+      if (attempt < maxRetries) {
+        const waitTime = Math.pow(2, attempt) * 1000; // 指数バックオフ: 2秒, 4秒, 8秒
+        console.log(`[OCR Detection] ${waitTime}ms待機後にリトライします...`);
+        await new Promise(resolve => setTimeout(resolve, waitTime));
+      } else {
+        // 最後の試行でも失敗した場合
+        console.error(`[OCR Detection] 全ての試行が失敗しました: ${maxRetries}回試行`);
+        throw error;
+      }
     }
-
-    const result = JSON.parse(jsonMatch[0]) as OcrDetectionResponse
-
-    // バリデーション
-    return {
-      company_id: result.company_id || null,
-      confidence: typeof result.confidence === 'number' ? result.confidence : 0,
-      detected_text: result.detected_text || '',
-      found_keywords: Array.isArray(result.found_keywords) ? result.found_keywords : [],
-      reasoning: result.reasoning || '',
-    }
-  } catch (error) {
-    console.error('[OCR Detection] Error calling Gemini API:', error)
-    throw error
   }
+  
+  // この行には到達しないはずだが、TypeScriptの型チェックのため
+  throw new Error('Unexpected error in performOcrCompanyDetection');
 }
 
 Deno.serve(async (req: Request) => {
@@ -323,8 +344,8 @@ Deno.serve(async (req: Request) => {
 
     // 2. Genクライアントの初期化
     const genAI = new GoogleGenAI({ apiKey: GEMINI_API_KEY })
-    const model = 'gemini-2.5-flash-preview-04-17' // または "gen-pro", "gen-1.5-pro-latest" など。速度とコストで選択。
-    // gemini-2.5-flash-preview-04-17 適応的思考、費用対効果
+    const model = 'gemini-2.5-flash-preview-05-20' // または "gen-pro", "gen-1.5-pro-latest" など。速度とコストで選択。
+    // gemini-2.5-flash-preview-05-20 最新版、改善された性能
     // gemini-2.5-pro-preview-05-06 思考と推論の強化、マルチモーダル理解、高度なコーディングなど
     // gemini-2.0-flash 次世代の機能、速度。
 
@@ -348,14 +369,21 @@ Deno.serve(async (req: Request) => {
     console.log(`[${new Date().toISOString()}] Sending prompt with PDF data to Gemini API for file: ${fileName}`)
     // console.debug("Full Prompt to Gen:", prompt); // デバッグ時に必要ならコメント解除 (非常に長くなる可能性)
 
-    // 4. Gemini API呼び出し
+    // 4. Gemini API呼び出し（リトライ機能付き）
     let generatedTextByGen: string = ''
     let usageMetadata: any = null
-    try {
-      // API Ref https://ai.google.dev/api/generate-content?hl=ja#v1beta.GenerateContentResponse
-      const response = await genAI.models.generateContent({
-        model: model,
-        contents: [{ role: 'user', parts: requestParts }], // マルチモーダル入力形式
+    
+    const maxRetries = 3;
+    let attempt = 0;
+    
+    while (attempt < maxRetries) {
+      try {
+        console.log(`[${new Date().toISOString()}] Gemini API呼び出し試行 ${attempt + 1}/${maxRetries} for ${fileName}`);
+        
+        // API Ref https://ai.google.dev/api/generate-content?hl=ja#v1beta.GenerateContentResponse
+        const response = await genAI.models.generateContent({
+          model: model,
+          contents: [{ role: 'user', parts: requestParts }], // マルチモーダル入力形式
         // role: 'user' はユーザーのメッセージを、role: 'model' はAIモデル自身の応答を示す
         // 安全性設定の例 (必要に応じて調整)
         // safetySettings: [
@@ -376,61 +404,75 @@ Deno.serve(async (req: Request) => {
         //     threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
         //   },
         // ],
-        // デベロッパーがシステム指示を設定
-        // systemInstruction: "",
-      })
-      if (typeof response.text === 'string' && response.text.trim().length > 0) {
-        generatedTextByGen = response.text
-      } else {
-        // response.text が undefined または空文字列だった場合の処理
-        console.error('response.text is undefined or empty:', response)
-        throw new Error('Gemini APIからの応答が空です。PDFの内容を確認してください。')
-      }
-      console.log(`[${new Date().toISOString()}] Successfully received response from Gemini API for: ${fileName}`)
-      usageMetadata = response.usageMetadata
+          // デベロッパーがシステム指示を設定
+          // systemInstruction: "",
+        })
+        
+        if (typeof response.text === 'string' && response.text.trim().length > 0) {
+          generatedTextByGen = response.text
+        } else {
+          // response.text が undefined または空文字列だった場合の処理
+          console.error('response.text is undefined or empty:', response)
+          throw new Error('Gemini APIからの応答が空です。PDFの内容を確認してください。')
+        }
+        
+        console.log(`[${new Date().toISOString()}] Successfully received response from Gemini API for: ${fileName}`)
+        usageMetadata = response.usageMetadata
 
-      // usageMetadata が存在する場合、トークン数をログに出力
-      if (usageMetadata) {
-        console.log(`Token Usage for ${fileName}:`)
-        console.log(`  Prompt Token Count: ${usageMetadata.promptTokenCount}`)
-        // candidatesTokenCount は存在する場合のみログに出力 (モデルや設定により異なる)
-        if (usageMetadata.candidatesTokenCount !== undefined) {
-          console.log(`  Candidates Token Count: ${usageMetadata.candidatesTokenCount}`)
+        // usageMetadata が存在する場合、トークン数をログに出力
+        if (usageMetadata) {
+          console.log(`Token Usage for ${fileName}:`)
+          console.log(`  Prompt Token Count: ${usageMetadata.promptTokenCount}`)
+          // candidatesTokenCount は存在する場合のみログに出力 (モデルや設定により異なる)
+          if (usageMetadata.candidatesTokenCount !== undefined) {
+            console.log(`  Candidates Token Count: ${usageMetadata.candidatesTokenCount}`)
+          }
+          // totalTokenCount は存在する場合のみログに出力
+          if (usageMetadata.totalTokenCount !== undefined) {
+            console.log(`  Total Token Count: ${usageMetadata.totalTokenCount}`)
+          }
+          // cachedContentTokenCount も存在する場合がある
+          if (usageMetadata.cachedContentTokenCount !== undefined) {
+            console.log(`  Cached Content Token Count: ${usageMetadata.cachedContentTokenCount}`)
+          }
+        } else {
+          console.log(`[${new Date().toISOString()}] usageMetadata not found in Gemini API response for: ${fileName}`)
         }
-        // totalTokenCount は存在する場合のみログに出力
-        if (usageMetadata.totalTokenCount !== undefined) {
-          console.log(`  Total Token Count: ${usageMetadata.totalTokenCount}`)
-        }
-        // cachedContentTokenCount も存在する場合がある
-        if (usageMetadata.cachedContentTokenCount !== undefined) {
-          console.log(`  Cached Content Token Count: ${usageMetadata.cachedContentTokenCount}`)
-        }
-      } else {
-        console.log(`[${new Date().toISOString()}] usageMetadata not found in Gemini API response for: ${fileName}`)
-      }
 
-      // console.debug("Gen Raw Response Text:", generatedTextByGen); // デバッグ時に必要ならコメント解除
-    } catch (genError: any) {
-      console.error(`[${new Date().toISOString()}] Error calling Gemini API for ${fileName}:`, genError)
-      let userFriendlyErrorMessage = 'AIによるテキスト生成に失敗しました。'
-      // Gemini APIからのエラーレスポンスに詳細が含まれていれば、それをログに出力
-      // genError.message にも情報が含まれることがある
-      // if (genError.response && genError.response.promptFeedback) {
-      //   console.error("Gemini API Prompt Feedback:", genError.response.promptFeedback);
-      //   if(genError.response.promptFeedback.blockReason){
-      //       userFriendlyErrorMessage += ` 理由: ${genError.response.promptFeedback.blockReason}`;
-      //   }
-      // }
-      return new Response(
-        JSON.stringify({
-          error: userFriendlyErrorMessage,
-          details: genError.message,
-        }),
-        {
-          status: 502, // Bad Gateway (外部APIとの連携で問題があった場合)
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        // 成功したらループを抜ける
+        break;
+        
+      } catch (genError: any) {
+        attempt++;
+        console.error(`[${new Date().toISOString()}] Gemini API呼び出し失敗 (試行 ${attempt}/${maxRetries}) for ${fileName}:`, genError);
+        
+        // 最後の試行でない場合は待機してリトライ
+        if (attempt < maxRetries) {
+          const waitTime = Math.pow(2, attempt) * 1000; // 指数バックオフ: 2秒, 4秒, 8秒
+          console.log(`[${new Date().toISOString()}] ${waitTime}ms待機後にリトライします...`);
+          await new Promise(resolve => setTimeout(resolve, waitTime));
+        } else {
+          // 最後の試行でも失敗した場合
+          console.error(`[${new Date().toISOString()}] 全ての試行が失敗しました for ${fileName}: ${maxRetries}回試行`);
+          let userFriendlyErrorMessage = `AIによるテキスト生成に失敗しました（${maxRetries}回試行）。`;
+          
+          // サーバーエラーの場合は一時的な問題の可能性を示唆
+          if (genError.message && genError.message.includes('500')) {
+            userFriendlyErrorMessage += ' 一時的なサーバーエラーの可能性があります。しばらく待ってから再度お試しください。';
+          }
+          
+          return new Response(
+            JSON.stringify({
+              error: userFriendlyErrorMessage,
+              details: genError.message,
+            }),
+            {
+              status: 502, // Bad Gateway (外部APIとの連携で問題があった場合)
+              headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            }
+          )
         }
-      )
+      }
     }
 
     // --- データベースへの保存処理 ---
@@ -535,6 +577,7 @@ Deno.serve(async (req: Request) => {
       identifiedCompany: companyIdFromFrontend,
       usageMetadata: usageMetadata, // トークン使用量も返す
       dbRecordId: dbRecordId, // DBに保存されたレコードのIDも返す (オプション)
+      workOrderId: dbRecordId, // フロントエンドの互換性のため追加
       // 自動判定の結果を含める
       detectionResult: detectionResult
         ? {

--- a/supabase/migrations/20250612140000_create_batch_processes_table.sql
+++ b/supabase/migrations/20250612140000_create_batch_processes_table.sql
@@ -1,0 +1,121 @@
+-- Create batch_processes table for tracking batch processing jobs
+CREATE TABLE IF NOT EXISTS batch_processes (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  status VARCHAR(50) NOT NULL DEFAULT 'pending',
+  total_files INTEGER NOT NULL,
+  processed_files INTEGER DEFAULT 0,
+  failed_files INTEGER DEFAULT 0,
+  company_id VARCHAR(100),
+  auto_detect_enabled BOOLEAN DEFAULT false,
+  options JSONB DEFAULT '{}',
+  started_at TIMESTAMPTZ DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Create batch_process_files table for tracking individual files in a batch
+CREATE TABLE IF NOT EXISTS batch_process_files (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  batch_process_id UUID REFERENCES batch_processes(id) ON DELETE CASCADE,
+  work_order_id UUID REFERENCES work_orders(id) ON DELETE SET NULL,
+  file_name VARCHAR(255) NOT NULL,
+  file_size INTEGER,
+  status VARCHAR(50) NOT NULL DEFAULT 'pending',
+  company_id VARCHAR(100),
+  detection_result JSONB,
+  error_message TEXT,
+  processing_time_ms INTEGER,
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Create indexes for better query performance
+CREATE INDEX idx_batch_processes_user_id ON batch_processes(user_id);
+CREATE INDEX idx_batch_processes_status ON batch_processes(status);
+CREATE INDEX idx_batch_processes_created_at ON batch_processes(created_at DESC);
+
+CREATE INDEX idx_batch_process_files_batch_process_id ON batch_process_files(batch_process_id);
+CREATE INDEX idx_batch_process_files_work_order_id ON batch_process_files(work_order_id);
+CREATE INDEX idx_batch_process_files_status ON batch_process_files(status);
+
+-- Add trigger to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_batch_processes_updated_at BEFORE UPDATE ON batch_processes
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_batch_process_files_updated_at BEFORE UPDATE ON batch_process_files
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Add RLS policies
+ALTER TABLE batch_processes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE batch_process_files ENABLE ROW LEVEL SECURITY;
+
+-- Users can view and manage their own batch processes
+CREATE POLICY "Users can view own batch processes" ON batch_processes
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own batch processes" ON batch_processes
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own batch processes" ON batch_processes
+    FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own batch processes" ON batch_processes
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- Users can view and manage batch process files for their own batches
+CREATE POLICY "Users can view own batch process files" ON batch_process_files
+    FOR SELECT USING (
+        EXISTS (
+            SELECT 1 FROM batch_processes 
+            WHERE batch_processes.id = batch_process_files.batch_process_id 
+            AND batch_processes.user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY "Users can insert own batch process files" ON batch_process_files
+    FOR INSERT WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM batch_processes 
+            WHERE batch_processes.id = batch_process_files.batch_process_id 
+            AND batch_processes.user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY "Users can update own batch process files" ON batch_process_files
+    FOR UPDATE USING (
+        EXISTS (
+            SELECT 1 FROM batch_processes 
+            WHERE batch_processes.id = batch_process_files.batch_process_id 
+            AND batch_processes.user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY "Users can delete own batch process files" ON batch_process_files
+    FOR DELETE USING (
+        EXISTS (
+            SELECT 1 FROM batch_processes 
+            WHERE batch_processes.id = batch_process_files.batch_process_id 
+            AND batch_processes.user_id = auth.uid()
+        )
+    );
+
+-- Add comments for documentation
+COMMENT ON TABLE batch_processes IS 'Stores batch processing jobs for multiple PDF files';
+COMMENT ON TABLE batch_process_files IS 'Stores individual file processing results within a batch';
+
+COMMENT ON COLUMN batch_processes.status IS 'Status of the batch: pending, processing, completed, cancelled, error';
+COMMENT ON COLUMN batch_processes.options IS 'JSON object containing batch processing options like concurrentLimit, pauseOnError, etc.';
+COMMENT ON COLUMN batch_process_files.detection_result IS 'JSON object containing company detection results';
+COMMENT ON COLUMN batch_process_files.processing_time_ms IS 'Processing time in milliseconds';


### PR DESCRIPTION
## 概要
開発ブランチ(dev)の最新機能をmainブランチにマージします。主に作業指示書ツールの大幅な機能強化と安定性向上が含まれています。

## 主な変更内容

### 新機能
- **一括処理機能**: 複数PDFファイルの自動処理機能を実装
- **ファイル閲覧機能**: 処理済みファイルの結果閲覧機能
- **エラーハンドリング強化**: Gemini APIエラー時の適切な状態表示
- **ファイルサイズ制限**: 5MBのバリデーション実装

### UI/UX改善  
- 「バッチ」表記を「一括」に統一
- 一括処理中の成功済みファイル閲覧機能
- 処理状態の視覚的表示改善
- エラー時のユーザーフィードバック向上

### 技術的改善
- Gemini APIモデルを最新版(gemini-2.5-flash-preview-05-20)に更新
- TypeScriptエラーの解決
- ESLint警告の修正
- CI/CDパイプラインの安定化

### バグ修正
- 一括処理での会社選定失敗問題の解決
- work_ordersテーブルのレコード作成問題の修正
- バッチ処理キャンセル時の状態保持問題の解決
- ファイル選択とデータ閲覧機能の不具合修正

## テスト
- [x] フロントエンドのlint/build確認済み
- [x] 一括処理機能の動作確認済み
- [x] エラーハンドリングの動作確認済み
- [x] 既存機能への影響なし確認済み

## 破壊的変更
なし - 既存機能は全て維持されています

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>