### PR TITLE
Issue #121: GeneratedTextPanelから仮のボタンを削除

### DIFF
--- a/frontend/src/components/workOrderTool/GeneratedTextPanel.tsx
+++ b/frontend/src/components/workOrderTool/GeneratedTextPanel.tsx
@@ -264,13 +264,6 @@ export const GeneratedTextPanel: React.FC<GeneratedTextPanelProps> = ({
               </Button>
             )}
 
-          {/* これらのボタンは現状ダミーなので、機能実装時にprops経由でハンドラを受け取る */}
-          <Button variant="outline" size="sm" disabled>
-            戻る (仮)
-          </Button>
-          <Button variant="outline" size="sm" disabled>
-            次へ (仮)
-          </Button>
         </div>
       </div>
       <div className="flex flex-col flex-1 gap-2 min-h-0">


### PR DESCRIPTION
## 概要
Issue #121の対応として、GeneratedTextPanelコンポーネントから機能未実装の仮のボタンを削除しました。

## 変更内容
- `GeneratedTextPanel.tsx`から以下の要素を削除:
  - 仮の「戻る (仮)」ボタン
  - 仮の「次へ (仮)」ボタン
  - 関連するコメント

## 削除理由
- これらのボタンは機能が未実装で無効化されていた
- UIの見た目をクリーンに保つため
- Issue #121で要求された通り

## テスト
- [x] ESLint チェック: パス
- [x] TypeScript ビルドチェック: パス
- [x] 本番ビルド: 成功
- [x] 他の機能に影響がないことを確認

## 影響範囲
- GeneratedTextPanelコンポーネントのUI表示のみ
- 既存の機能には影響なし
- 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)