### PR TITLE
feat: ホームページに作業指示書ツールへの遷移ボタンを追加

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,3 +1,19 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+
 export default function Home() {
-  return <h1 className="text-3xl font-bold p-6">🏠 ホーム画面</h1>;
+  const navigate = useNavigate();
+
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold mb-6">🏠 ホーム画面</h1>
+      <Button 
+        onClick={() => navigate('/admin/work-order-tool')}
+        variant="default"
+        size="lg"
+      >
+        📄 作業指示書ツールへ
+      </Button>
+    </div>
+  );
 }


### PR DESCRIPTION
## 概要
ホームページに作業指示書ツールへのナビゲーションボタンを追加しました。

Closes #117

## 変更内容
- Home.tsxにReact RouterのuseNavigateフックを導入
- shadcn/uiのButtonコンポーネントを使用
- 大きめのボタン（size="lg"）で視認性を向上
- `/admin/work-order-tool`へのナビゲーションを実装

🤖 Generated with [Claude Code](https://claude.ai/code)