### PR TITLE
🔄 refactor: KATOUBENIYA_MISAWA を KATOUBENIYA_IKEBUKURO_MISAWA に統一 (#130)

### DIFF
--- a/frontend/src/constants/company.ts
+++ b/frontend/src/constants/company.ts
@@ -4,7 +4,7 @@ import type { CompanyOption } from '@/types';
 export const COMPANY_OPTIONS: readonly CompanyOption[] = [
   // 既存実装済み（2社）
   { value: 'NOHARA_G', label: '野原G住環境' },
-  { value: 'KATOUBENIYA_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
+  { value: 'KATOUBENIYA_IKEBUKURO_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
   
   // 親会社単体（27社）
   { value: 'SONOTA', label: 'その他' },

--- a/frontend/src/test/CompanyAutoDetectToggle.test.tsx
+++ b/frontend/src/test/CompanyAutoDetectToggle.test.tsx
@@ -116,7 +116,7 @@ describe('CompanyAutoDetectToggle', () => {
 
     it('中信頼度の判定結果が正しく表示される', () => {
       const detectionResult: CompanyDetectionResult = {
-        detectedCompanyId: 'KATOUBENIYA_MISAWA',
+        detectedCompanyId: 'KATOUBENIYA_IKEBUKURO_MISAWA',
         confidence: 0.75,
         method: 'ocr_gemini',
         details: {
@@ -133,7 +133,7 @@ describe('CompanyAutoDetectToggle', () => {
         />
       );
 
-      expect(screen.getByText('KATOUBENIYA_MISAWA')).toBeInTheDocument();
+      expect(screen.getByText('KATOUBENIYA_IKEBUKURO_MISAWA')).toBeInTheDocument();
       expect(screen.getByText('中信頼度 75%')).toBeInTheDocument();
       expect(
         screen.getByText('検出キーワード: 加藤ベニヤ')

--- a/frontend/src/test/WorkOrderTool.integration.test.tsx
+++ b/frontend/src/test/WorkOrderTool.integration.test.tsx
@@ -116,11 +116,11 @@ vi.mock('@/hooks/useDragAndDrop', () => ({
 vi.mock('@/constants/company', () => ({
   COMPANY_OPTIONS: [
     { value: 'NOHARA_G', label: '野原G住環境' },
-    { value: 'KATOUBENIYA_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
+    { value: 'KATOUBENIYA_IKEBUKURO_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
   ],
   ALL_COMPANY_OPTIONS: [
     { value: 'NOHARA_G', label: '野原G住環境' },
-    { value: 'KATOUBENIYA_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
+    { value: 'KATOUBENIYA_IKEBUKURO_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
     { value: 'UNKNOWN_OR_NOT_SET', label: '会社を特定できませんでした' },
   ],
 }));

--- a/frontend/src/test/companyAutoDetection.test.ts
+++ b/frontend/src/test/companyAutoDetection.test.ts
@@ -27,7 +27,7 @@ describe('会社自動判定機能', () => {
         },
         {
           input: '加藤ベニヤ池袋 ミサワホーム 工事',
-          expected: 'KATOUBENIYA_MISAWA',
+          expected: 'KATOUBENIYA_IKEBUKURO_MISAWA',
           confidence: 0.85,
           description: '加藤ベニヤ + ミサワホームの組み合わせ',
         },
@@ -78,17 +78,17 @@ describe('会社自動判定機能', () => {
       const testCases = [
         {
           text: '加藤ベニヤ ミサワホーム',
-          expectedCompany: 'KATOUBENIYA_MISAWA',
+          expectedCompany: 'KATOUBENIYA_IKEBUKURO_MISAWA',
           minConfidence: 0.8,
         },
         {
           text: '加藤ベニヤ',
-          expectedCompany: 'KATOUBENIYA_MISAWA',
+          expectedCompany: 'KATOUBENIYA_IKEBUKURO_MISAWA',
           minConfidence: 0.6,
         },
         {
           text: 'ミサワホーム',
-          expectedCompany: 'KATOUBENIYA_MISAWA',
+          expectedCompany: 'KATOUBENIYA_IKEBUKURO_MISAWA',
           minConfidence: 0.6,
         },
       ];
@@ -167,24 +167,24 @@ function simulateOcrDetection(text: string): {
   // 加藤ベニヤ + ミサワホーム複合判定
   else if (text.includes('加藤ベニヤ') && text.includes('ミサワホーム')) {
     foundKeywords.push('加藤ベニヤ', 'ミサワホーム');
-    detectedCompany = 'KATOUBENIYA_MISAWA';
+    detectedCompany = 'KATOUBENIYA_IKEBUKURO_MISAWA';
     confidence = 0.85;
     reasoning = '加藤ベニヤとミサワホームの複合キーワードを検出';
   }
   // 個別キーワード
   else if (text.includes('加藤ベニヤ池袋')) {
     foundKeywords.push('加藤ベニヤ池袋');
-    detectedCompany = 'KATOUBENIYA_MISAWA';
+    detectedCompany = 'KATOUBENIYA_IKEBUKURO_MISAWA';
     confidence = 0.8;
     reasoning = '加藤ベニヤ池袋キーワードを検出';
   } else if (text.includes('加藤ベニヤ')) {
     foundKeywords.push('加藤ベニヤ');
-    detectedCompany = 'KATOUBENIYA_MISAWA';
+    detectedCompany = 'KATOUBENIYA_IKEBUKURO_MISAWA';
     confidence = 0.7;
     reasoning = '加藤ベニヤキーワードを検出';
   } else if (text.includes('ミサワホーム')) {
     foundKeywords.push('ミサワホーム');
-    detectedCompany = 'KATOUBENIYA_MISAWA';
+    detectedCompany = 'KATOUBENIYA_IKEBUKURO_MISAWA';
     confidence = 0.6;
     reasoning = 'ミサワホームキーワードを検出';
   } else {

--- a/frontend/src/test/mocks/FACTORY_USAGE.md
+++ b/frontend/src/test/mocks/FACTORY_USAGE.md
@@ -75,7 +75,7 @@ import { createMockWorkOrderForCompany } from './mocks/factories';
 const noharaWorkOrder = createMockWorkOrderForCompany('NOHARA_G');
 
 // 加藤ベニヤのワークオーダー
-const katouWorkOrder = createMockWorkOrderForCompany('KATOUBENIYA_MISAWA');
+const katouWorkOrder = createMockWorkOrderForCompany('KATOUBENIYA_IKEBUKURO_MISAWA');
 ```
 
 ### エラー状態データ
@@ -362,7 +362,7 @@ const testEmail = randomHelpers.email();
 const testString = randomHelpers.string(12);
 const randomCompany = randomHelpers.arrayElement([
   'NOHARA_G',
-  'KATOUBENIYA_MISAWA',
+  'KATOUBENIYA_IKEBUKURO_MISAWA',
 ]);
 ```
 

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -538,7 +538,7 @@ export const testPresets = {
   // 企業別のワークオーダー
   companySpecificData: () => ({
     noharaG: createMockWorkOrderForCompany('NOHARA_G'),
-    katoubeniya: createMockWorkOrderForCompany('KATOUBENIYA_MISAWA'),
+    katoubeniya: createMockWorkOrderForCompany('KATOUBENIYA_IKEBUKURO_MISAWA'),
     yamadaK: createMockWorkOrderForCompany('YAMADA_K'),
   }),
 };

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -61,7 +61,7 @@ const createTestUsersDatabase = () => [
     role: 'staff',
     user_metadata: {
       password: 'katou123',
-      company: 'KATOUBENIYA_MISAWA',
+      company: 'KATOUBENIYA_IKEBUKURO_MISAWA',
     },
   }),
 ];
@@ -599,7 +599,7 @@ export const edgeFunctionHandlers = [
 
       if (
         companyId &&
-        ['NOHARA_G', 'KATOUBENIYA_MISAWA', 'YAMADA_K'].includes(companyId)
+        ['NOHARA_G', 'KATOUBENIYA_IKEBUKURO_MISAWA', 'YAMADA_K'].includes(companyId)
       ) {
         // 会社固有のレスポンス
         const workOrder = createMockWorkOrderForCompany(companyId);
@@ -639,7 +639,7 @@ let mockShifts: MockShift[] = [];
 const initializeMockDatabase = () => {
   mockWorkOrders = [
     createMockWorkOrderForCompany('NOHARA_G', { id: 1 }),
-    createMockWorkOrderForCompany('KATOUBENIYA_MISAWA', { id: 2 }),
+    createMockWorkOrderForCompany('KATOUBENIYA_IKEBUKURO_MISAWA', { id: 2 }),
     ...createMockWorkOrders(3, { status: 'completed' }),
   ];
 

--- a/frontend/src/test/twoStageProcessing.integration.test.tsx
+++ b/frontend/src/test/twoStageProcessing.integration.test.tsx
@@ -159,14 +159,14 @@ describe('2段階処理 統合テスト', () => {
     it('加藤ベニヤ_ミサワホームの2段階処理が正常に動作する', async () => {
       const stage1Response: PdfProcessSuccessResponse = {
         generatedText: '',
-        identifiedCompany: 'KATOUBENIYA_MISAWA',
+        identifiedCompany: 'KATOUBENIYA_IKEBUKURO_MISAWA',
         originalFileName: 'test-katou.pdf',
         promptUsedIdentifier: 'ocr-prompt',
         dbRecordId: 'stage1-uuid',
         ocrOnly: true,
         fileName: 'test-katou.pdf',
         detectionResult: {
-          detectedCompanyId: 'KATOUBENIYA_MISAWA',
+          detectedCompanyId: 'KATOUBENIYA_IKEBUKURO_MISAWA',
           confidence: 0.87,
           method: 'ocr_gemini',
           details: {

--- a/frontend/src/test/usePdfProcessor.test.ts
+++ b/frontend/src/test/usePdfProcessor.test.ts
@@ -213,14 +213,14 @@ describe('usePdfProcessor Hook', () => {
     it('OCR処理の結果が適切に処理される', async () => {
       const mockOcrResponse: PdfProcessSuccessResponse = {
         generatedText: '',
-        identifiedCompany: 'KATOUBENIYA_MISAWA',
+        identifiedCompany: 'KATOUBENIYA_IKEBUKURO_MISAWA',
         originalFileName: 'test.pdf',
         promptUsedIdentifier: 'ocr-prompt',
         dbRecordId: 'test-uuid',
         ocrOnly: true,
         fileName: 'test.pdf',
         detectionResult: {
-          detectedCompanyId: 'KATOUBENIYA_MISAWA',
+          detectedCompanyId: 'KATOUBENIYA_IKEBUKURO_MISAWA',
           confidence: 0.87,
           method: 'ocr_gemini',
           details: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,7 +5,7 @@
 export type CompanyOptionValue = 
   // 既存実装済み（2社）
   | 'NOHARA_G' 
-  | 'KATOUBENIYA_MISAWA' 
+  | 'KATOUBENIYA_IKEBUKURO_MISAWA' 
   | 'YAMADA_K' 
   | 'UNKNOWN_OR_NOT_SET' 
   | ''
@@ -81,7 +81,7 @@ export interface CompanyOption {
 // 会社固有定数（テスト用）
 export const COMPANY_OPTIONS_CONST: readonly CompanyOption[] = [
   { value: 'NOHARA_G', label: '野原G住環境' },
-  { value: 'KATOUBENIYA_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
+  { value: 'KATOUBENIYA_IKEBUKURO_MISAWA', label: '加藤ベニヤ池袋_ミサワホーム' },
   { value: 'YAMADA_K', label: '山田K建設 (準備中)' },
   { value: 'UNKNOWN_OR_NOT_SET', label: '会社を特定できませんでした' },
 ] as const;


### PR DESCRIPTION
## 概要

Issue #130 の実装です。加藤ベニヤ池袋_ミサワホーム用の識別子を命名規則に従って統一しました。

**変更内容**: `KATOUBENIYA_MISAWA` → `KATOUBENIYA_IKEBUKURO_MISAWA`

## 変更理由

1. **命名の一貫性**: 他の会社（例: `KATOUBENIYA_IKEBUKURO_HAWKONE`）は地域名を含んでいる
2. **区別の明確化**: 朝霧と池袋の加藤ベニヤを明確に区別
3. **将来の拡張性**: 他の地域の加藤ベニヤが追加される場合に備えて

## 変更ファイル（23ファイル）

### 🔧 バックエンド（8ファイル）
- `prompts/katouBeniyaIkebukuro/misawa.ts` - 関数名変更
- `promptRegistry.ts` - インポート文とレジストリキー
- `index.ts` - CompanyIdentifier型定義
- `companyDetector.ts` - 会社ID（3箇所）
- `ocrPrompt.ts` - コメント（2箇所）
- **新規**: `migrations/20250619203853_rename_katoubeniya_misawa_to_ikebukuro_misawa.sql`

### 🎨 フロントエンド（2ファイル）
- `constants/company.ts` - COMPANY_OPTIONS配列
- `types/index.ts` - CompanyOptionValue型定義とテスト用定数

### 🧪 テストファイル（10ファイル）
- フロントエンド: 6ファイル
- バックエンド: 4ファイル

### 📚 ドキュメント（3ファイル）
- `CLAUDE.md`
- `frontend/src/test/mocks/FACTORY_USAGE.md`
- `supabase/functions/_shared/test-helpers/README.md`

## データベースマイグレーション

```sql
-- work_ordersテーブルのprompt_identifierを更新
UPDATE work_orders 
SET prompt_identifier = 'KATOUBENIYA_IKEBUKURO_MISAWA' 
WHERE prompt_identifier = 'KATOUBENIYA_MISAWA';

-- company_detection_rulesテーブルのcompany_idを更新
UPDATE company_detection_rules 
SET company_id = 'KATOUBENIYA_IKEBUKURO_MISAWA' 
WHERE company_id = 'KATOUBENIYA_MISAWA';
```

## テスト結果

- ✅ ESLint: エラーなし
- ✅ TypeScriptビルド: エラーなし
- ✅ フロントエンドビルド: 成功（警告はPDF.jsのサイズによるもの）

## チェックリスト

- [x] コードは一貫性のある命名規則に従っている
- [x] すべての参照箇所を更新した
- [x] データベースマイグレーションを含む
- [x] テストとドキュメントを更新
- [x] ビルドが成功する
- [x] 破壊的変更への対処（マイグレーション）

## 関連

- Closes #130

🤖 Generated with [Claude Code](https://claude.ai/code)